### PR TITLE
Correct pointer references and method calls

### DIFF
--- a/devolay-natives/src/main/cpp/framesync.cpp
+++ b/devolay-natives/src/main/cpp/framesync.cpp
@@ -3,16 +3,16 @@
 #include "me_walkerknapp_devolay_DevolayFrameSync.h"
 
 JNIEXPORT jlong JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncCreate(JNIEnv *env, jclass jClazz, jlong pReceiver) {
-    return (jlong) getNDILib()->framesync_create(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver));
+    return (jlong) getNDILib()->framesync_create(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncDestroy(JNIEnv *env, jclass jClazz, jlong pFramesync) {
-    getNDILib()->framesync_destroy(reinterpret_cast<NDIlib_framesync_instance_t *>(pFramesync));
+    getNDILib()->framesync_destroy(reinterpret_cast<NDIlib_framesync_instance_t>(pFramesync));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncCaptureAudio
         (JNIEnv *env, jclass jClazz, jlong pFramesync, jlong pFrame, jint jSampleRate, jint jNoChannels, jint jNoSamples) {
-    getNDILib()->framesync_capture_audio(reinterpret_cast<NDIlib_framesync_instance_t *>(pFramesync),
+    getNDILib()->framesync_capture_audio(reinterpret_cast<NDIlib_framesync_instance_t>(pFramesync),
             reinterpret_cast<NDIlib_audio_frame_v2_t *>(pFrame),
             jSampleRate, jNoChannels, jNoSamples);
 }
@@ -25,13 +25,13 @@ JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncCap
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncFreeAudio
         (JNIEnv *env, jclass jClazz, jlong pFramesync, jlong pFrame) {
-    getNDILib()->framesync_free_audio(reinterpret_cast<NDIlib_framesync_instance_t *>(pFramesync),
+    getNDILib()->framesync_free_audio(reinterpret_cast<NDIlib_framesync_instance_t>(pFramesync),
             reinterpret_cast<NDIlib_audio_frame_v2_t *>(pFrame));
 }
 
 JNIEXPORT jboolean JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncCaptureVideo
         (JNIEnv *env, jclass jClazz, jlong pFramesync, jlong pFrame, jint jFrameFormatType) {
-    getNDILib()->framesync_capture_video(reinterpret_cast<NDIlib_framesync_instance_t *>(pFramesync),
+    getNDILib()->framesync_capture_video(reinterpret_cast<NDIlib_framesync_instance_t>(pFramesync),
             reinterpret_cast<NDIlib_video_frame_v2_t *>(pFrame),
             (NDIlib_frame_format_type_e)jFrameFormatType);
 
@@ -40,6 +40,6 @@ JNIEXPORT jboolean JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyn
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayFrameSync_framesyncFreeVideo
         (JNIEnv *env, jclass jClazz, jlong pFramesync, jlong pFrame) {
-    getNDILib()->framesync_free_video(reinterpret_cast<NDIlib_framesync_instance_t *>(pFramesync),
+    getNDILib()->framesync_free_video(reinterpret_cast<NDIlib_framesync_instance_t>(pFramesync),
             reinterpret_cast<NDIlib_video_frame_v2_t *>(pFrame));
 }

--- a/devolay-natives/src/main/cpp/receiver.cpp
+++ b/devolay-natives/src/main/cpp/receiver.cpp
@@ -35,15 +35,15 @@ JNIEXPORT jlong JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveCreat
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveDestroy(JNIEnv *env, jclass jClazz, jlong pReceiver) {
-    delete reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver);
+    delete reinterpret_cast<NDIlib_recv_instance_t>(pReceiver);
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveConnect(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pSource) {
-    getNDILib()->recv_connect(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver), reinterpret_cast<NDIlib_source_t *>(pSource));
+    getNDILib()->recv_connect(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver), reinterpret_cast<NDIlib_source_t *>(pSource));
 }
 
 JNIEXPORT jint JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveCaptureV2(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pVideoFrame, jlong pAudioFrame, jlong pMetadataFrame, jint timeout) {
-    return getNDILib()->recv_capture_v2(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    return getNDILib()->recv_capture_v2(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                                   reinterpret_cast<NDIlib_video_frame_v2_t *>(pVideoFrame),
                                   reinterpret_cast<NDIlib_audio_frame_v2_t *>(pAudioFrame),
                                   reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame),
@@ -51,47 +51,47 @@ JNIEXPORT jint JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveCaptur
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_freeVideoV2(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pVideoFrame) {
-    getNDILib()->recv_free_video_v2(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    getNDILib()->recv_free_video_v2(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                               reinterpret_cast<NDIlib_video_frame_v2_t *>(pVideoFrame));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_freeAudioV2(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pAudioFrame) {
-    getNDILib()->recv_free_audio_v2(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    getNDILib()->recv_free_audio_v2(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                               reinterpret_cast<NDIlib_audio_frame_v2_t *>(pAudioFrame));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_freeMetadata(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pMetadataFrame) {
-    getNDILib()->recv_free_metadata(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    getNDILib()->recv_free_metadata(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                               reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame));
 }
 
 JNIEXPORT jboolean JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveSendMetadata(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pMetadataFrame) {
-    return getNDILib()->recv_send_metadata(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    return getNDILib()->recv_send_metadata(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                                      reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveGetPerformance(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pTotalPerformance, jlong pDroppedPerformance) {
-    getNDILib()->recv_get_performance(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    getNDILib()->recv_get_performance(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                                 reinterpret_cast<NDIlib_recv_performance_t *>(pTotalPerformance),
                                 reinterpret_cast<NDIlib_recv_performance_t *>(pDroppedPerformance));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveClearConnectionMetadata(JNIEnv *env, jclass jClazz, jlong pReceiver) {
-    getNDILib()->recv_clear_connection_metadata(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver));
+    getNDILib()->recv_clear_connection_metadata(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver));
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveAddConnectionMetadata(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pMetadataFrame) {
-    getNDILib()->recv_add_connection_metadata(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
+    getNDILib()->recv_add_connection_metadata(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver),
                                         reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame));
 }
 
 JNIEXPORT jint JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveGetNoConnections(JNIEnv *env, jclass jClazz, jlong pReceiver) {
-    return getNDILib()->recv_get_no_connections(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver));
+    return getNDILib()->recv_get_no_connections(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver));
 }
 
 JNIEXPORT jstring JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveGetWebControl(JNIEnv *env, jclass jClazz, jlong pReceiver) {
-    const char *webControl = getNDILib()->recv_get_web_control(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver));
+    const char *webControl = getNDILib()->recv_get_web_control(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver));
     auto *ret = env->NewStringUTF(webControl);
-    getNDILib()->recv_free_string(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver), webControl);
+    getNDILib()->recv_free_string(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver), webControl);
     return ret;
 }

--- a/devolay-natives/src/main/cpp/sender.cpp
+++ b/devolay-natives/src/main/cpp/sender.cpp
@@ -107,12 +107,12 @@ JNIEXPORT jlong JNICALL Java_me_walkerknapp_devolay_DevolaySender_getSource(JNIE
 }
 
 JNIEXPORT jint JNICALL Java_me_walkerknapp_devolay_DevolaySender_sendCapture(JNIEnv *env, jclass jClazz, jlong pSender, jlong pMetadataFrame, jint jTimeout) {
-    return getNDILib()->send_capture(reinterpret_cast<NDIlib_send_instance_t *>(pSender),
+    return getNDILib()->send_capture(reinterpret_cast<NDIlib_send_instance_t>(pSender),
                                      reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame),
                                      jTimeout);
 }
 
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolaySender_freeMetadata(JNIEnv *env, jclass jClazz, jlong pSender, jlong pMetadataFrame) {
-    getNDILib()->recv_free_metadata(reinterpret_cast<NDIlib_send_instance_t *>(pSender),
+    getNDILib()->send_free_metadata(reinterpret_cast<NDIlib_send_instance_t>(pSender),
                               reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame));
 }


### PR DESCRIPTION
The headers in the current SDK release define instance references as pointers.  This was causing compilation errors when casting as a pointer (`<NDIlib_recv_instance_t *>`).  I'm not sure if this was changed at some point or not, but the library would not compile for me without these changes.

```cpp
struct NDIlib_framesync_instance_type;
typedef struct NDIlib_framesync_instance_type* NDIlib_framesync_instance_t;

struct NDIlib_send_instance_type;
typedef struct NDIlib_send_instance_type* NDIlib_send_instance_t;

struct NDIlib_recv_instance_type;
typedef struct NDIlib_recv_instance_type* NDIlib_recv_instance_t;
```

I also changed the `recv_free_metadata` call in sender.cpp to `send_free_metadata`

