### PR TITLE
Add `setTally` method for DevolayReceiver

### DIFF
--- a/devolay-java/src/main/java/me/walkerknapp/devolay/DevolayReceiver.java
+++ b/devolay-java/src/main/java/me/walkerknapp/devolay/DevolayReceiver.java
@@ -209,7 +209,15 @@ public class DevolayReceiver extends DevolayFrameCleaner implements AutoCloseabl
         return receiveSendMetadata(ndilibRecievePointer, metadataFrame.structPointer);
     }
 
-    // TODO: NDIlib_recv_set_tally
+    /**
+     * Set tally state on the source
+     *
+     * @param tally The {@link DevolayTally} state to send.
+     * @return true if a source is connected, false if the receiver is disconnected.
+     */
+    public boolean setTally(DevolayTally tally) {
+        return receiveSetTally(ndilibRecievePointer, tally.isOnProgram(), tally.isOnPreview());
+    }
 
     /**
      * Fills in a {@link DevolayPerformanceData} structure with performance information about the receiver.
@@ -296,6 +304,7 @@ public class DevolayReceiver extends DevolayFrameCleaner implements AutoCloseabl
     private static native void freeAudioV2(long structPointer, long pAudioFrame);
     private static native void freeMetadata(long structPointer, long pMetadata);
     private static native boolean receiveSendMetadata(long structPointer, long pMetadataFrame);
+    private static native boolean receiveSetTally(long structPointer, boolean isOnProgram, boolean isOnPreview);
 
     private static native void receiveGetPerformance(long structPointer, long pTotalPerformance, long pDroppedPerformance);
 

--- a/devolay-java/src/main/java/me/walkerknapp/devolay/DevolayTally.java
+++ b/devolay-java/src/main/java/me/walkerknapp/devolay/DevolayTally.java
@@ -15,7 +15,7 @@ public class DevolayTally {
      * @param isOnProgram If the current sender is being displayed on program.
      * @param isOnPreview If the current sender is being displayed on preview.
      */
-    DevolayTally(boolean isOnProgram, boolean isOnPreview) {
+    public DevolayTally(boolean isOnProgram, boolean isOnPreview) {
         this.isOnProgram = isOnProgram;
         this.isOnPreview = isOnPreview;
     }

--- a/devolay-natives/src/main/cpp/receiver.cpp
+++ b/devolay-natives/src/main/cpp/receiver.cpp
@@ -70,6 +70,14 @@ JNIEXPORT jboolean JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveSe
                                      reinterpret_cast<NDIlib_metadata_frame_t *>(pMetadataFrame));
 }
 
+JNIEXPORT jboolean JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveSetTally(JNIEnv *env, jclass jClazz, jlong pReceiver, jboolean jProgram, jboolean jPreview) {
+    NDIlib_tally_t tally_create;
+    tally_create.on_program = static_cast<bool>(jProgram);
+    tally_create.on_preview = static_cast<bool>(jPreview);
+    auto ret = getNDILib()->recv_set_tally(reinterpret_cast<NDIlib_recv_instance_t>(pReceiver), &tally_create);
+    return ret;
+}
+
 JNIEXPORT void JNICALL Java_me_walkerknapp_devolay_DevolayReceiver_receiveGetPerformance(JNIEnv *env, jclass jClazz, jlong pReceiver, jlong pTotalPerformance, jlong pDroppedPerformance) {
     getNDILib()->recv_get_performance(reinterpret_cast<NDIlib_recv_instance_t *>(pReceiver),
                                 reinterpret_cast<NDIlib_recv_performance_t *>(pTotalPerformance),


### PR DESCRIPTION
I implemented `NDIlib_recv_set_tally` and added the appropriate public methods (at least as best as I could figure out how to).

Tested the build on some NDI devices and it appears to be working properly.  Please let me know if there's a different method signature you would rather have (and if the constructor for `DevolayTally` needs to remain private).

The CI build may fail without the changes in #29 btw